### PR TITLE
Remove require.js and use native esm modules.

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1,5 +1,5 @@
-import { drawPattern } from "./pattern";
-import { getUrlParam, insertUrlParam, isColor } from "./utils";
+import { drawPattern } from "./pattern.js";
+import { getUrlParam, insertUrlParam, isColor } from "./utils.js";
 
 const backgroundInput = document.forms[0][
   "backgroundInput"

--- a/horizontal.ts
+++ b/horizontal.ts
@@ -1,12 +1,12 @@
-import { drawPattern } from "./pattern";
-import { PatternProps, Sequence, Stroke } from "./types";
+import { drawPattern } from "./pattern.js";
+import { PatternProps, Sequence, Stroke } from "./types.js";
 import {
   convertBooleanUrlParam,
   getUrlParam,
   insertUrlParam,
   isColor,
   removeUrlParam,
-} from "./utils";
+} from "./utils.js";
 
 const sequenceInput = document.forms[0][
   "horizontalSequence"

--- a/index.html
+++ b/index.html
@@ -142,8 +142,5 @@
       </div>
     </div>
   </body>
-  <script
-    data-main="build/index"
-    src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.3/require.min.js"
-  ></script>
+  <script type="module" src="./build/index.js"></script>
 </html>

--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,11 @@
-import { drawPattern } from "./pattern";
-import "./sidebar";
-import "./horizontal";
-import "./vertical";
-import "./background";
+import { drawPattern } from "./pattern.js";
+import "./sidebar.js";
+import "./horizontal.js";
+import "./vertical.js";
+import "./background.js";
 
 function resizeCanvas() {
+  const canvas = document.getElementById("myCanvas") as HTMLCanvasElement;
   canvas.width =
     window.innerWidth ||
     document.documentElement.clientWidth ||

--- a/pattern.ts
+++ b/pattern.ts
@@ -1,11 +1,11 @@
-import { DISTANCE_APART } from "./constants";
+import { DISTANCE_APART } from "./constants.js";
 import {
   PatternProps,
   GetBitProps,
   Sequence,
   Stroke,
   StrokeOptions,
-} from "./types";
+} from "./types.js";
 import {
   charToBinary,
   convertBooleanUrlParam,
@@ -16,7 +16,7 @@ import {
   isColor,
   isEven,
   isVowel,
-} from "./utils";
+} from "./utils.js";
 
 type DrawPatternProps = {
   verticalOptions?: PatternProps;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "module": "amd",
-    "target": "es5",
+    "module": "es6",
+    "target": "es6",
+    "moduleResolution": "classic",
     "noImplicitAny": true,
     "removeComments": true,
     "preserveConstEnums": true,

--- a/vertical.ts
+++ b/vertical.ts
@@ -1,12 +1,12 @@
-import { drawPattern } from "./pattern";
-import { PatternProps, Sequence, Stroke } from "./types";
+import { drawPattern } from "./pattern.js";
+import { PatternProps, Sequence, Stroke } from "./types.js";
 import {
   convertBooleanUrlParam,
   getUrlParam,
   insertUrlParam,
   isColor,
   removeUrlParam,
-} from "./utils";
+} from "./utils.js";
 
 const sequenceInput = document.forms[0]["verticalSequence"] as HTMLInputElement;
 


### PR DESCRIPTION
This makes the website only work with new browsers.
Support for ES6 is very wide spread so it's fine by me.
Decreases js downloaded on load.